### PR TITLE
Workaround for lame tag crc check failure

### DIFF
--- a/src/attachmeta.py
+++ b/src/attachmeta.py
@@ -178,7 +178,7 @@ def get_the_song(artist_and_song):
     return song_data
 
 
-def set_data(song_name_file='index', DEBUG=True):
+def set_data(song_name_file='index', DEBUG=False):
     """
     Sets the metadata to the song files, using eyed3 module
     If this function is called using main, then it searches for a file


### PR DESCRIPTION
This changes log level to ERRORS, hence the warning is skipped. This fixes issue #3 