### PR TITLE
Add directory flexibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,12 @@
 A file to keep a log of changes made in this project.
 
 --------------------
+#### [unreleased]
+==========================
+* [2018-06-21]
+    * Added the directory flexibility
+
+--------------------
 ### Syncing
 ==========================
 --------------------

--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ $ sync-music ~/complete/path/to/dir ~/other_dir
 ```
 
 This uploads the songs in the directory to your dropbox, and also attaches metadata to them before uploading.
-#### CAUTION
-Make sure that the path to directories you give either starts with a dot ```.``` like ```./Mymusic/``` (relative path from current working directory) or with home directory symbol ```~``` like ```~/Mymusic/classic/``` (complete path). Because, current version of the app won't be able to find directories if you would give their path as ```../../dir```.
 
 #### To download
 Following command will download all your uploaded songs to ```~/Music/```.

--- a/src/sync_music.py
+++ b/src/sync_music.py
@@ -274,7 +274,8 @@ def ask_to_proceed(reason=""):
 
 
 @click.command()
-@click.argument('dirs', nargs=-1, required=False)
+@click.argument('dirs', nargs=-1, required=False,
+                type=click.Path(exists=True, dir_okay=True, resolve_path=True))
 @click.option('--config', '-c',  nargs=2, type=str,
               help="To set API token: "
               "--config dropbox.key 'token'")


### PR DESCRIPTION
This commit uses click to resolve path names when they are supplied. So now we don't need to supply a `.` when we are supplying a folder from current directory.