### PR TITLE
setup.sh can now be run repeatedly

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,11 +1,16 @@
-
-pip install pipenv
+pip install -U pipenv --user
 pipenv install .
 
 echo -e "\nCreating directory structure..."
-mkdir -p ~/.sync-music/tmpfiles/
-mkdir -p ~/.sync-music/scripts/
-mkdir -p ~/.sync-music/config/
+if [ -d ~/.sync-music/tmpfiles ]; then
+    mkdir -p ~/.sync-music/tmpfiles/
+fi
+if [ -d ~/.sync-music/scripts ]; then
+    mkdir -p ~/.sync-music/scripts/
+fi
+if [ -d ~/.sync-music/config ]; then
+    mkdir -p ~/.sync-music/config/
+fi
 
 echo -e "\nMaking data files..."
 touch ~/.sync-music/tmpfiles/index.tmp
@@ -18,5 +23,9 @@ chmod +x ./src/generate_temp_files.sh
 chmod +x ./src/sync_music.py
 
 echo -e "\nCreating required symlinks..."
-ln -s ./src/generate_temp_files.sh ~/.sync-music/scripts/generate_temp_files.sh 
-sudo ln ./src/sync_music.py /usr/bin/sync-music
+if [ ! -L ~/.sync-music/scripts/generate_temp_files.sh ]; then
+    ln -s ./src/generate_temp_files.sh ~/.sync-music/scripts/generate_temp_files.sh 
+fi
+if [ ! -f $HOME/bin/sync-music ]; then 
+    ln ./src/sync_music.py $HOME/bin/sync-music
+fi


### PR DESCRIPTION
`setup.sh` now checks before creating directory, or symlinks or hard links
This enables setup.sh to be run again in case the `~/.sync-music` folder's
structure is damaged.